### PR TITLE
Remove invalid string conversion warnings

### DIFF
--- a/src/eib/bus_hal.cpp
+++ b/src/eib/bus_hal.cpp
@@ -24,7 +24,7 @@ void BusHal::isrCallbackUpdate(TIM_HandleTypeDef* ahtim)
     }
 }
 
-void BusHal::_Error_Handler(char* filename, int line)
+void BusHal::_Error_Handler(char const* filename, int line)
 {
     while(1) {}
 }

--- a/src/eib/bus_hal.h
+++ b/src/eib/bus_hal.h
@@ -81,7 +81,7 @@ public:
     void setPwmMatch(unsigned int pwmMatch);
     void isrCallbackCapture(TIM_HandleTypeDef* ahtim);
     void isrCallbackUpdate(TIM_HandleTypeDef* ahtim);
-    void _Error_Handler(char* filename, int line);
+    void _Error_Handler(char const* filename, int line);
     stimer_t _timer; // TODO static?
 protected:
     int rxTimerValue = 0;


### PR DESCRIPTION
This pull request removes warning about invalid conversion from string constant to char * in bus_hal file

More specifically this warning (repeated multiples times)
"stm32_def.h:75:58: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]"
